### PR TITLE
Check jetpack is active

### DIFF
--- a/jetpack-force-2fa.php
+++ b/jetpack-force-2fa.php
@@ -20,7 +20,7 @@ class Jetpack_Force_2FA {
 		$this->role = apply_filters( 'jetpack_force_2fa_cap', 'manage_options' );
 		
 		// Bail if Jetpack SSO is not active
-		if ( ! class_exists( 'Jetpack' ) || ! Jetpack::is_module_active( 'sso' ) ) {
+		if ( ! class_exists( 'Jetpack' ) || ! Jetpack::is_active() || ! Jetpack::is_module_active( 'sso' ) ) {
 			add_action( 'admin_notices', array( $this, 'admin_notice' ) );
 			return;
 		}


### PR DESCRIPTION
It's possible for the SSO module to be active without Jetpack being connected. In that case, we would be blocking local logins even though SSO is not available.

Fixes #15