### PR TITLE
Check for WP_Error on wp_authenticate_user

### DIFF
--- a/jetpack-force-2fa.php
+++ b/jetpack-force-2fa.php
@@ -59,6 +59,9 @@ class Jetpack_Force_2FA {
 		else {
 			// Completely disable the standard login form for admins.
 			add_filter( 'wp_authenticate_user', function( $user ) {
+				if ( is_wp_error( $user ) ) {
+					return $user;
+				}
 				if ( $user->has_cap( $this->role ) ) {
 					return new WP_Error( 'wpcom-required', $this->get_login_error_message(), $user->user_login );
 				}


### PR DESCRIPTION
When something returns a `WP_Error` during authentication (like an invalid password), we shouldn't be trying to access `->has_cap()` of that error object, but rather return it immediately.