### PR TITLE
Load Jetpack Force 2FA later

### DIFF
--- a/jetpack-force-2fa.php
+++ b/jetpack-force-2fa.php
@@ -13,7 +13,7 @@ class Jetpack_Force_2FA {
 	private $role;
 
 	function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
+		add_action( 'after_setup_theme', array( $this, 'plugins_loaded' ) );
 	}
 
 	function plugins_loaded() {


### PR DESCRIPTION
On VIP Go, we enabled this plugin on `setup_theme` because there may be some theme settings that factor into whether the plugin is enabled or not. We therefore can't force 2fa before after_setup_theme. This should be fine in all cases because the theme is set up before logins happen.